### PR TITLE
Fix reply highlight styling to avoid text overrides

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,13 +9,14 @@
 
 .slack-enhancer-reply-highlight {
     background-color: #FFEBEE !important;
-    border: 2px solid #FF5252 !important;
     border-radius: 4px !important;
-    color: #D50000 !important;
-    font-weight: bold !important;
-    padding: 2px 6px !important;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
-    transition: all 0.2s ease-in-out !important;
+    box-shadow: 0 0 0 2px #FF5252 inset !important;
+    color: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: inherit !important;
+    transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out !important;
 }
 
 .slack-enhancer-reply-highlight:hover {


### PR DESCRIPTION
### Motivation
- Fix a bug where the reply-count highlight could unintentionally change Slack text color and size, causing red and enlarged reply links.
- Preserve the visual emphasis (background, border, hover) while keeping Slack's native typography intact.

### Description
- Updated `styles.css` for the `.slack-enhancer-reply-highlight` rule to remove explicit `color`, `font-size`, `font-weight`, `padding`, and `border` declarations.
- Replaced the visible border with an inset `box-shadow: 0 0 0 2px #FF5252 inset` so the outline is drawn without affecting text layout.
- Added `color: inherit`, `font-size: inherit`, `font-weight: inherit`, `line-height: inherit`, and `text-decoration: inherit` to preserve Slack typography, and limited `transition` to `transform` and `background-color` only.
- Retained the hover behavior (`transform` scale and background color change) for the emphasis effect.

### Testing
- No automated tests were run because this is a style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697877ca7f2483319da4613f632f575c)