### PR TITLE
Limit reply highlight to thread pane and remove hover scaling

### DIFF
--- a/content.js
+++ b/content.js
@@ -78,9 +78,30 @@ function highlightreplies(rootNode) {
 }
 
 function applyHighlight(element) {
+    if (!isInThreadPane(element)) {
+        return;
+    }
     if (!element.classList.contains('slack-enhancer-reply-highlight')) {
         element.classList.add('slack-enhancer-reply-highlight');
     }
+}
+
+function isInThreadPane(element) {
+    const threadPaneSelectors = [
+        '[data-qa="thread_panel"]',
+        '[data-qa="thread_view"]',
+        '[data-qa="thread"]',
+        '#threads_view',
+        '.p-threads_view',
+        '.p-threads',
+        '.p-threads__view',
+        '.c-threads',
+        '.c-threads_container',
+        '.c-threads_section',
+        '.c-thread_pane'
+    ];
+
+    return Boolean(element.closest(threadPaneSelectors.join(', ')));
 }
 
 function replaceAtlassianLinks(rootNode) {

--- a/styles.css
+++ b/styles.css
@@ -16,10 +16,4 @@
     font-weight: inherit !important;
     line-height: inherit !important;
     text-decoration: inherit !important;
-    transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out !important;
-}
-
-.slack-enhancer-reply-highlight:hover {
-    transform: scale(1.05);
-    background-color: #FFCDD2 !important;
 }


### PR DESCRIPTION
### Motivation
- The reply-count highlight was being applied to unopened-thread reply links and the hover scaling/transform altered Slack’s native text styling and hover behavior.
- The intent is to restrict visual emphasis to the thread view (right pane) and let unopened-thread links keep Slack’s default rendering and hover behavior.

### Description
- Updated `content.js` to only add the `slack-enhancer-reply-highlight` class inside thread panes by changing `applyHighlight` to early-return when `!isInThreadPane(element)` and adding the `isInThreadPane` helper.
- Implemented `isInThreadPane` with a set of thread-related selectors so the highlight is only applied when `element.closest(...)` matches thread containers.
- Cleaned up `styles.css` by removing transform/transition and `:hover` rules so the highlight only provides background/border and preserves Slack text styling.

### Testing
- No automated tests were run for these style/selector updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c76f59cb48331ab0f832f9132265c)