### PR TITLE
Highlight only "◯件の返信" reply count when > 0

### DIFF
--- a/content.js
+++ b/content.js
@@ -53,55 +53,26 @@ function highlightreplies(rootNode) {
     const replyElements = rootNode.querySelectorAll(selector);
 
     replyElements.forEach(el => {
-        // Verify it's not the main message input or something else
-        const text = el.textContent || "";
-
-        // Check for numbers match
-        const hasNumber = /\d/.test(text);
-
-        // Specific check for "Other replies" (その他の返信)
-        const isOtherReplies = text.includes("その他の返信") || text.includes("other replies");
-
-        if (hasNumber || isOtherReplies) {
+        const text = (el.textContent || "").trim();
+        if (isReplyCountText(text)) {
             applyHighlight(el);
         }
     });
+}
 
-    // 3. Text content fallback (for "Other replies" that might not match above selectors)
-    // This is more expensive, so we scope it carefully if possible, or just scan buttons.
-    const buttons = rootNode.querySelectorAll('button, div[role="button"]');
-    buttons.forEach(btn => {
-        if (btn.textContent.includes("その他の返信") || btn.textContent.includes("other replies")) {
-            applyHighlight(btn);
-        }
-    });
+function isReplyCountText(text) {
+    const match = text.match(/^(\d+)\s*件の返信$/);
+    if (!match) {
+        return false;
+    }
+    const count = Number.parseInt(match[1], 10);
+    return Number.isFinite(count) && count > 0;
 }
 
 function applyHighlight(element) {
-    if (!isInThreadPane(element)) {
-        return;
-    }
     if (!element.classList.contains('slack-enhancer-reply-highlight')) {
         element.classList.add('slack-enhancer-reply-highlight');
     }
-}
-
-function isInThreadPane(element) {
-    const threadPaneSelectors = [
-        '[data-qa="thread_panel"]',
-        '[data-qa="thread_view"]',
-        '[data-qa="thread"]',
-        '#threads_view',
-        '.p-threads_view',
-        '.p-threads',
-        '.p-threads__view',
-        '.c-threads',
-        '.c-threads_container',
-        '.c-threads_section',
-        '.c-thread_pane'
-    ];
-
-    return Boolean(element.closest(threadPaneSelectors.join(', ')));
 }
 
 function replaceAtlassianLinks(rootNode) {

--- a/styles.css
+++ b/styles.css
@@ -8,12 +8,6 @@
 */
 
 .slack-enhancer-reply-highlight {
-    background-color: #FFEBEE !important;
-    border-radius: 4px !important;
-    box-shadow: 0 0 0 2px #FF5252 inset !important;
-    color: inherit !important;
-    font-size: inherit !important;
-    font-weight: inherit !important;
-    line-height: inherit !important;
-    text-decoration: inherit !important;
+    color: #d72b3f !important;
+    font-weight: 600 !important;
 }


### PR DESCRIPTION
### Motivation
- Improve visibility of the "◯件の返信" reply-count text so users can more easily notice there are replies while keeping changes minimal and non-invasive.

### Description
- Narrowed matching to an exact Japanese reply-count pattern by adding `isReplyCountText` which uses the regex `/^(\d+)\s*件の返信$/` and only returns true for counts `> 0`.
- Apply the `.slack-enhancer-reply-highlight` class only to elements whose text matches the reply-count pattern via `applyHighlight` instead of the previous broader matching logic.
- Simplified styling for the highlight by updating `.slack-enhancer-reply-highlight` to `color: #d72b3f` and `font-weight: 600` to provide clear emphasis without layout changes.
- Removed the previous `isInThreadPane` restriction so the highlight is applied wherever the exact reply-count text appears in the DOM.

### Testing
- No automated tests were executed for this change because it is a content-script and CSS-only modification in the extension; visual verification in a running Slack client is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c7b32d1d08331aabb0294aba3f592)